### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Notice: This repository stopped working properly after changes were made early o
 🚨🚨🚨
 
 
-#iOSSwiftOpenGLCamera
+# iOSSwiftOpenGLCamera
 
 ![Example](without_shader.gif) ![Example](with_shader.gif)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
